### PR TITLE
remove bibrefs from abstract

### DIFF
--- a/draft-inadarei-prefer-transclude-xml-01.xml
+++ b/draft-inadarei-prefer-transclude-xml-01.xml
@@ -18,7 +18,7 @@
             </address>
         </author>
         <date day="15" month="September" year="2016" />
-        <abstract><t>The specification for Transclude preference is an extension to the  Prefer Header for HTTP <xref target="RFC7240" />. It works similar to other preferences defined in <xref target="RFC7240" />, such as: return, respond-async, wait and handling.</t>
+        <abstract><t>The specification for Transclude preference is an extension to the "Prefer Header for HTTP". It works similar to other preferences defined in the Prefer header field, such as: return, respond-async, wait and handling.</t>
         </abstract>
         <note title="Note to Readers">
             <t>Please discuss this draft on the apps-discuss mailing list (<eref target="https://www.ietf.org/mailman/listinfo/apps-discuss"/>).</t>


### PR DESCRIPTION
it's better to not have references in the abstract. it should be useful as "standalone text".
